### PR TITLE
Feat: add signature when calling checkout widget

### DIFF
--- a/woocommerce-gateway-wompi/includes/admin/class-wc-wompi-admin-notices.php
+++ b/woocommerce-gateway-wompi/includes/admin/class-wc-wompi-admin-notices.php
@@ -53,9 +53,11 @@ class WC_Wompi_Admin_Notices {
 		$test_pub_key       = isset( $options['test_public_key'] ) ? $options['test_public_key'] : '';
 		$test_secret_key    = isset( $options['test_private_key'] ) ? $options['test_private_key'] : '';
 		$test_event_secret_key    = isset( $options['test_event_secret_key'] ) ? $options['test_event_secret_key'] : '';
+		$test_integrity_key       = isset( $options['test_integrity_key'] ) ? $options['test_integrity_key'] : '';
 		$live_pub_key       = isset( $options['public_key'] ) ? $options['public_key'] : '';
 		$live_secret_key    = isset( $options['private_key'] ) ? $options['private_key'] : '';
-		$event_secret_key    = isset( $options['event_secret_key'] ) ? $options['event_secret_key'] : '';
+		$event_secret_key   = isset( $options['event_secret_key'] ) ? $options['event_secret_key'] : '';
+		$integrity_key      = isset( $options['integrity_key'] ) ? $options['integrity_key'] : '';
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
 
@@ -70,6 +72,7 @@ class WC_Wompi_Admin_Notices {
                     empty( $test_pub_key ) ||
                     empty( $test_secret_key ) ||
                     empty( $test_event_secret_key ) ||
+                    empty( $test_integrity_key ) ||
                     empty( $supported_currency ) ) {
                     $this->add_admin_notice( 'wc_wompi', 'notice notice-error', sprintf( __( 'Wompi is in test mode however your test keys may not be valid. Please go to your settings and, <a href="%s">set your Wompi account keys</a>.', 'woocommerce-gateway-wompi' ), $setting_link ) );
                     $keys_valid = false;
@@ -79,6 +82,7 @@ class WC_Wompi_Admin_Notices {
                     empty( $live_pub_key ) ||
                     empty( $live_secret_key ) ||
                     empty( $event_secret_key ) ||
+                    empty( $integrity_key ) ||
                     empty( $supported_currency ) ) {
                     $this->add_admin_notice( 'wc_wompi', 'notice notice-error', sprintf( __( 'Wompi is in live mode however your live keys may not be valid. Please go to your settings and, <a href="%s">set your Wompi account keys</a>.', 'woocommerce-gateway-wompi' ), $setting_link ) );
                     $keys_valid = false;

--- a/woocommerce-gateway-wompi/includes/admin/wompi-settings.php
+++ b/woocommerce-gateway-wompi/includes/admin/wompi-settings.php
@@ -59,6 +59,13 @@ return apply_filters(
 			'default'     => '',
 			'desc_tip'    => true,
 		),
+		'test_integrity_key' => array(
+			'title'       => __( 'Test Integrity Key', 'woocommerce-gateway-wompi' ),
+			'type'        => 'password',
+			'description' => __( 'Get your API keys from your Wompi account.', 'woocommerce-gateway-wompi' ),
+			'default'     => '',
+			'desc_tip'    => true,
+		),
 		'public_key' => array(
 			'title'       => __( 'Live Public Key', 'woocommerce-gateway-wompi' ),
 			'type'        => 'text',
@@ -75,6 +82,13 @@ return apply_filters(
 		),
 		'event_secret_key' => array(
 			'title'       => __( 'Live Event Private Key', 'woocommerce-gateway-wompi' ),
+			'type'        => 'password',
+			'description' => __( 'Get your API keys from your Wompi account.', 'woocommerce-gateway-wompi' ),
+			'default'     => '',
+			'desc_tip'    => true,
+		),
+		'integrity_key' => array(
+			'title'       => __( 'Live Integrity Key', 'woocommerce-gateway-wompi' ),
 			'type'        => 'password',
 			'description' => __( 'Get your API keys from your Wompi account.', 'woocommerce-gateway-wompi' ),
 			'default'     => '',

--- a/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi-custom.php
+++ b/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi-custom.php
@@ -40,15 +40,21 @@ class WC_Gateway_Wompi_Custom extends WC_Payment_Gateway {
     public function generate_wompi_widget( $order_id ) {
         $order = new WC_Order( $order_id );
 
+        $amount_in_cents = WC_Wompi_Helper::get_amount_in_cents( $order->get_total() );
+        $integrity_key =  WC_Wompi::$settings['testmode'] === 'yes' ? WC_Wompi::$settings['test_integrity_key'] : WC_Wompi::$settings['integrity_key'];
+        $currency = get_woocommerce_currency();
+        $signature = hash('sha256',  "{$order_id}{$amount_in_cents}{$currency}{$integrity_key}");
+
         $out = '';
         $out .= '<div class="wompi-button-holder">';
         $out .= '
             <script
                 src="https://checkout.wompi.co/widget.js"
                 data-render="button"
-                data-public-key="'.( WC_Wompi::$settings['testmode'] === 'yes' ? WC_Wompi::$settings['test_public_key'] : WC_Wompi::$settings['public_key'] ).'"
-                data-currency="'.get_woocommerce_currency().'"
-                data-amount-in-cents="'.WC_Wompi_Helper::get_amount_in_cents( $order->get_total() ).'"
+                data-signature:integrity="'. $signature .'"
+                data-public-key="'. ( WC_Wompi::$settings['testmode'] === 'yes' ? WC_Wompi::$settings['test_public_key'] : WC_Wompi::$settings['public_key'] ) .'"
+                data-currency="'. $currency .'"
+                data-amount-in-cents="'. $amount_in_cents .'"
                 data-reference="'.$order_id.'"
                 data-redirect-url="'.$order->get_checkout_order_received_url().'"
                 >

--- a/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi-custom.php
+++ b/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi-custom.php
@@ -16,6 +16,8 @@ class WC_Gateway_Wompi_Custom extends WC_Payment_Gateway {
     public $event_secret_key;
     public static $supported_currency = false;
 
+    private $checkout_url = "https://checkout.wompi.co";
+
     /**
      * Init hooks
      */
@@ -41,28 +43,26 @@ class WC_Gateway_Wompi_Custom extends WC_Payment_Gateway {
         $order = new WC_Order( $order_id );
 
         $amount_in_cents = WC_Wompi_Helper::get_amount_in_cents( $order->get_total() );
+        $public_key = WC_Wompi::$settings['testmode'] === 'yes' ? WC_Wompi::$settings['test_public_key'] : WC_Wompi::$settings['public_key'];
         $integrity_key =  WC_Wompi::$settings['testmode'] === 'yes' ? WC_Wompi::$settings['test_integrity_key'] : WC_Wompi::$settings['integrity_key'];
         $currency = get_woocommerce_currency();
         $signature = hash('sha256',  "{$order_id}{$amount_in_cents}{$currency}{$integrity_key}");
 
-        $out = '';
-        $out .= '<div class="wompi-button-holder">';
-        $out .= '
+        echo "
+        <div class='wompi-button-holder'>
             <script
-                src="https://checkout.wompi.co/widget.js"
-                data-render="button"
-                data-signature:integrity="'. $signature .'"
-                data-public-key="'. ( WC_Wompi::$settings['testmode'] === 'yes' ? WC_Wompi::$settings['test_public_key'] : WC_Wompi::$settings['public_key'] ) .'"
-                data-currency="'. $currency .'"
-                data-amount-in-cents="'. $amount_in_cents .'"
-                data-reference="'.$order_id.'"
-                data-redirect-url="'.$order->get_checkout_order_received_url().'"
+                src='{$this->checkout_url}/widget.js'
+                data-render='button'
+                data-signature:integrity='$signature'
+                data-public-key='$public_key'
+                data-currency='$currency'
+                data-amount-in-cents='$amount_in_cents'
+                data-reference='$order_id'
+                data-redirect-url='{$order->get_checkout_order_received_url()}'
                 >
             </script>
-        ';
-        $out .= '</div>';
-
-        echo $out;
+        </div>
+        ";
     }
 
     /**

--- a/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi.php
+++ b/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi.php
@@ -30,6 +30,7 @@ class WC_Gateway_Wompi extends WC_Gateway_Wompi_Custom {
         $this->public_key  = $this->testmode ? $options['test_public_key'] : $options['public_key'];
         $this->private_key = $this->testmode ? $options['test_private_key'] : $options['private_key'];
         $this->event_secret_key = $this->testmode ? $options['test_event_secret_key'] : $options['event_secret_key'];
+        $this->integrity_key = $this->testmode ? $options['test_integrity_key'] : $options['integrity_key'];
 
         // Hooks
         add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
@@ -42,16 +43,17 @@ class WC_Gateway_Wompi extends WC_Gateway_Wompi_Custom {
      * Checks to see if all criteria is met before showing payment method
      */
     public function is_available() {
-				if ( ! parent::is_available() ||
-						 ! $this->private_key ||
-						 ! $this->public_key ||
-						 ! $this->event_secret_key ||
-						 ! in_array( get_woocommerce_currency(), self::get_supported_currency() )
-				) {
-						return false;
-				}
+        if ( ! parent::is_available() ||
+             ! $this->private_key ||
+             ! $this->public_key ||
+             ! $this->event_secret_key ||
+             ! $this->integrity_key ||
+             ! in_array( get_woocommerce_currency(), self::get_supported_currency() )
+        ) {
+            return false;
+        }
 
-				return true;
+        return true;
     }
 
     /**

--- a/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi.php
+++ b/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi.php
@@ -27,10 +27,10 @@ class WC_Gateway_Wompi extends WC_Gateway_Wompi_Custom {
         $this->supports = array(
             'products'
         );
-        $this->public_key  = $this->testmode ? $options['test_public_key'] : $options['public_key'];
-        $this->private_key = $this->testmode ? $options['test_private_key'] : $options['private_key'];
-        $this->event_secret_key = $this->testmode ? $options['test_event_secret_key'] : $options['event_secret_key'];
-        $this->integrity_key = $this->testmode ? $options['test_integrity_key'] : $options['integrity_key'];
+        $this->public_key       = $this->testmode == 'yes' ? $options['test_public_key'] : $options['public_key'];
+        $this->private_key      = $this->testmode == 'yes' ? $options['test_private_key'] : $options['private_key'];
+        $this->event_secret_key = $this->testmode == 'yes' ? $options['test_event_secret_key'] : $options['event_secret_key'];
+        $this->integrity_key    = $this->testmode == 'yes' ? $options['test_integrity_key'] : $options['integrity_key'];
 
         // Hooks
         add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
@@ -43,17 +43,12 @@ class WC_Gateway_Wompi extends WC_Gateway_Wompi_Custom {
      * Checks to see if all criteria is met before showing payment method
      */
     public function is_available() {
-        if ( ! parent::is_available() ||
-             ! $this->private_key ||
-             ! $this->public_key ||
-             ! $this->event_secret_key ||
-             ! $this->integrity_key ||
-             ! in_array( get_woocommerce_currency(), self::get_supported_currency() )
-        ) {
-            return false;
-        }
-
-        return true;
+        return parent::is_available() &&
+             ! empty( $this->private_key ) &&
+             ! empty( $this->public_key ) &&
+             ! empty( $this->event_secret_key ) &&
+             ! empty( $this->integrity_key ) &&
+             in_array( get_woocommerce_currency(), self::get_supported_currency() );
     }
 
     /**

--- a/woocommerce-gateway-wompi/tests/bootstrap.php
+++ b/woocommerce-gateway-wompi/tests/bootstrap.php
@@ -34,9 +34,11 @@ function _manually_load_plugin() {
 			"test_public_key" => "pub_test_XXXXXXXXXXXX",
 			"test_private_key" => "prv_test_XXXXXXXXXXXX",
 			"test_event_secret_key" => "test_events_XXXXXXXXXXXX",
+			"test_integrity_key" => "test_integrity_XXXXXXXXXXXX",
 			"public_key" => "pub_prod_XXXXXXXXXXXX",
 			"private_key" => "prv_prod_XXXXXXXXXXXX",
 			"event_secret_key" => "prod_events_XXXXXXXXXXXX",
+			"integrity_key" => "prod_integrity_XXXXXXXXXXXX",
 			"logging" => "yes",
 		];
 	});


### PR DESCRIPTION
Added integrity keys to wompi settings page. The integrity key is now used to generate a signature during a transaction.