### PR TITLE
Update class-wc-gateway-wompi-custom.php

### DIFF
--- a/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi-custom.php
+++ b/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi-custom.php
@@ -14,6 +14,7 @@ class WC_Gateway_Wompi_Custom extends WC_Payment_Gateway {
     public $public_key;
     public $private_key;
     public $event_secret_key;
+    public $integrity_key;
     public static $supported_currency = false;
 
     private $checkout_url = "https://checkout.wompi.co";


### PR DESCRIPTION
Sin la propiedad -$integrity_key- de la clase class-wc-gateway-wompi-custom en php 8.2 la aplicacion falla.

El error corregido es el siguiente:  Deprecated: Creation of dynamic property WC_Gateway_Wompi::$integrity_key is deprecated in /wp-content/plugins/woocommerce-gateway-wompi/includes/class-wc-gateway-wompi.php on line 33